### PR TITLE
전체 복약정보 API 구현

### DIFF
--- a/src/main/java/com/WhatIsMethIs/config/exception/medicine/MedicineException.java
+++ b/src/main/java/com/WhatIsMethIs/config/exception/medicine/MedicineException.java
@@ -1,0 +1,10 @@
+package com.WhatIsMethIs.config.exception.medicine;
+
+import com.WhatIsMethIs.config.exception.ApplicationException;
+import org.springframework.http.HttpStatus;
+
+public class MedicineException extends ApplicationException {
+    protected MedicineException(String errorCode, HttpStatus httpStatus, String message) {
+        super(errorCode, httpStatus, message);
+    }
+}

--- a/src/main/java/com/WhatIsMethIs/config/exception/medicine/MedicineExceptionList.java
+++ b/src/main/java/com/WhatIsMethIs/config/exception/medicine/MedicineExceptionList.java
@@ -1,0 +1,15 @@
+package com.WhatIsMethIs.config.exception.medicine;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MedicineExceptionList {
+    NOT_FOUND_MEDICINE_ID_ERROR("M0001", HttpStatus.NOT_FOUND, "해당 id로 Medicine을 찾을 수 없습니다.");
+
+    private final String errorCode;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/WhatIsMethIs/config/exception/medicine/NotFoundMedicineIdException.java
+++ b/src/main/java/com/WhatIsMethIs/config/exception/medicine/NotFoundMedicineIdException.java
@@ -1,0 +1,7 @@
+package com.WhatIsMethIs.config.exception.medicine;
+
+public class NotFoundMedicineIdException extends MedicineException{
+    public NotFoundMedicineIdException(){
+        super(MedicineExceptionList.NOT_FOUND_MEDICINE_ID_ERROR.getErrorCode(), MedicineExceptionList.NOT_FOUND_MEDICINE_ID_ERROR.getHttpStatus(), MedicineExceptionList.NOT_FOUND_MEDICINE_ID_ERROR.getMessage());
+    }
+}

--- a/src/main/java/com/WhatIsMethIs/src/controller/MedicationController.java
+++ b/src/main/java/com/WhatIsMethIs/src/controller/MedicationController.java
@@ -10,6 +10,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @RequestMapping("/app/medications")
 @RestController
@@ -49,5 +51,28 @@ public class MedicationController {
     @PostMapping("")
     public BaseResponse<MedicationIdRes> createMedication(@RequestBody MedicationInfoReq medicationInfo) throws BaseException {
         return new BaseResponse<>(medicationService.createMedication(medicationInfo));
+    }
+
+    /**
+     * 3.3.1 index로 복약정보 수정
+     * [PATCH] /medications/:index
+     */
+    @Operation(description = "index로 복약정보를 수정하는 api로, 수정된 복약정보 index를 반환합니다. ",
+            summary = "3.3.1 복약정보 수정")
+    @PatchMapping("/{index}")
+    public BaseResponse<MedicationIdRes> updateMedication(@PathVariable("index") Long index, @RequestBody MedicationInfoReq medicationInfo) throws BaseException {
+        return new BaseResponse<>(medicationService.updateMedication(index, medicationInfo));
+    }
+
+    /**
+     * 3.4.1 index 리스트로 복약정보 삭제
+     * [DELETE] /medications
+     */
+    @Operation(description = "삭제할 복약정보 index들이 담긴 List로 복약정보를 삭제합니다. ",
+            summary = "3.4.1 복약정보 삭제")
+    @DeleteMapping("")
+    public BaseResponse<String> deleteMedication(@RequestParam List<Long> medicationIdList) throws BaseException {
+        medicationService.deleteMedication(medicationIdList);
+        return new BaseResponse<>("복약정보들이 성공적으로 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/WhatIsMethIs/src/controller/MedicationController.java
+++ b/src/main/java/com/WhatIsMethIs/src/controller/MedicationController.java
@@ -31,6 +31,17 @@ public class MedicationController {
     }
 
     /**
+     * 3.1.2 오늘의 복약정보 조회
+     * [GET] /medications/today
+     */
+    @Operation(description = "오늘의 복약정보를 조회하는 api로, (약물명, 약물이미지, 복용시간, 1회 복용량)을 반환합니다. ",
+           summary = "3.1.2 오늘의 복약정보 조회")
+    @GetMapping("/today")
+    public BaseResponse<List<MedicationShortInfoRes>> getTodayMedication() throws BaseException {
+        return new BaseResponse<>(medicationService.getTodayMedication());
+    }
+
+    /**
      * 3.1.3 복약정보 전체 조회
      * [GET] /medications/all/:page
      */
@@ -39,7 +50,7 @@ public class MedicationController {
             summary = "3.1.3 복약정보 전체 조회")
     @GetMapping("/all/{page}")
     public BaseResponse<MedicationShortInfoListRes> getAllMedication(@PathVariable("page") int page) throws BaseException {
-        return new BaseResponse<>(medicationService.getMedicationShortInfoList(page));
+        return new BaseResponse<>(medicationService.getAllMedication(page));
     }
 
     /**

--- a/src/main/java/com/WhatIsMethIs/src/controller/MedicationController.java
+++ b/src/main/java/com/WhatIsMethIs/src/controller/MedicationController.java
@@ -15,7 +15,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/app/medications")
 @RestController
-@Tag(name = "Medication", description = "복약정보 API")
+@Tag(name = "MEDICATION", description = "복약정보 API")
 public class MedicationController {
     private final MedicationService medicationService;
 
@@ -34,7 +34,7 @@ public class MedicationController {
      * 3.1.2 오늘의 복약정보 조회
      * [GET] /medications/today
      */
-    @Operation(description = "오늘의 복약정보를 조회하는 api로, (약물명, 약물이미지, 복용시간, 1회 복용량)을 반환합니다. ",
+    @Operation(description = "오늘의 복약정보를 조회하는 api로, (복약정보 index, 약물명, 약물이미지, 복용시간, 1회 복용량)을 반환합니다. ",
            summary = "3.1.2 오늘의 복약정보 조회")
     @GetMapping("/today")
     public BaseResponse<List<MedicationShortInfoRes>> getTodayMedication() throws BaseException {
@@ -45,7 +45,7 @@ public class MedicationController {
      * 3.1.3 복약정보 전체 조회
      * [GET] /medications/all/:page
      */
-    @Operation(description = "복약정보 전체를 조회하는 api로, MedicationShortInfoRes DTO(약물명, 약물이미지, 복용시간, 1회 복용량)와 전체 페이지 수를 반환합니다. " +
+    @Operation(description = "복약정보 전체를 조회하는 api로, (복약정보 index, 약물명, 약물이미지, 복용시간, 1회 복용량)와 전체 페이지 수를 반환합니다. " +
             "(단, page 변수는 0부터 시작)",
             summary = "3.1.3 복약정보 전체 조회")
     @GetMapping("/all/{page}")

--- a/src/main/java/com/WhatIsMethIs/src/controller/MedicationController.java
+++ b/src/main/java/com/WhatIsMethIs/src/controller/MedicationController.java
@@ -2,6 +2,7 @@ package com.WhatIsMethIs.src.controller;
 
 import com.WhatIsMethIs.config.BaseException;
 import com.WhatIsMethIs.config.BaseResponse;
+import com.WhatIsMethIs.src.dto.medication.MedicationReqDto.*;
 import com.WhatIsMethIs.src.dto.medication.MedicationResDto.*;
 import com.WhatIsMethIs.src.service.MedicationService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/app/medications")
 @RestController
-@Tag(name = "Medication API", description = "복약정보 API")
+@Tag(name = "Medication", description = "복약정보 API")
 public class MedicationController {
     private final MedicationService medicationService;
 
@@ -20,11 +21,33 @@ public class MedicationController {
      * 3.1.1 index로 복약정보 조회
      * [GET] /medications/:index
      */
-    @Operation(method = "GET",
-            description = "복약정보 1개을 조회하는 api로, MedicationInfoRes DTO를 반환합니다. (단, 본인의 복약정보만 조회 가능) ",
-                    summary = "3.1.1 복약정보 index로 복약정보 1개 조회")
+    @Operation(description = "복약정보 1개를 조회하는 api로, (약물명, 약물이미지, 1회 복용량, 복용시작/종료일, 복용시간, 복용주기, 알림시간, 설명)을 반환합니다. (단, 본인의 복약정보만 조회 가능) " +
+            "* nullable : notificationTime,", summary = "3.1.1 복약정보 index로 복약정보 1개 조회")
     @GetMapping("/{index}")
     public BaseResponse<MedicationInfoRes> getMedicationWithIndex(@PathVariable("index") Long index) throws BaseException {
         return new BaseResponse<>(medicationService.getMedicationWithIndex(index));
+    }
+
+    /**
+     * 3.1.3 복약정보 전체 조회
+     * [GET] /medications/all/:page
+     */
+    @Operation(description = "복약정보 전체를 조회하는 api로, MedicationShortInfoRes DTO(약물명, 약물이미지, 복용시간, 1회 복용량)와 전체 페이지 수를 반환합니다. " +
+            "(단, page 변수는 0부터 시작)",
+            summary = "3.1.3 복약정보 전체 조회")
+    @GetMapping("/all/{page}")
+    public BaseResponse<MedicationShortInfoListRes> getAllMedication(@PathVariable("page") int page) throws BaseException {
+        return new BaseResponse<>(medicationService.getMedicationShortInfoList(page));
+    }
+
+    /**
+     * 3.2.1 복약정보 등록
+     * [POST] /medications
+     */
+    @Operation(description = "복약정보를 등록하는 api로, 등록된 복약정보 index를 반환합니다. ",
+            summary = "3.2.1 복약정보 등록")
+    @PostMapping("")
+    public BaseResponse<MedicationIdRes> createMedication(@RequestBody MedicationInfoReq medicationInfo) throws BaseException {
+        return new BaseResponse<>(medicationService.createMedication(medicationInfo));
     }
 }

--- a/src/main/java/com/WhatIsMethIs/src/dto/medication/MedicationReqDto.java
+++ b/src/main/java/com/WhatIsMethIs/src/dto/medication/MedicationReqDto.java
@@ -1,0 +1,26 @@
+package com.WhatIsMethIs.src.dto.medication;
+
+import com.WhatIsMethIs.src.entity.MedicationConstant;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@NoArgsConstructor
+public class MedicationReqDto {
+    @Getter
+    public static class MedicationInfoReq{
+        private String medicineId; //등록되지 않은 약품일 경우 0 -> medicineId가 0인 약품 미리 만들어 놔야...
+        private String medicineName;
+        private String medicineImage;
+        private int takeCapacity;
+        private LocalDate takeStartDate;
+        private LocalDate takeEndDate;
+        private MedicationConstant.TakeMealTime takeMealTime; //아침, 점심, 저녁
+        private MedicationConstant.TakeBeforeAfter takeBeforeAfter; //식전, 식후
+        private int takeCycle; // 1달: -1, 30일: +30
+        private LocalTime notificationTime;
+        private String description;
+    }
+}

--- a/src/main/java/com/WhatIsMethIs/src/dto/medication/MedicationResDto.java
+++ b/src/main/java/com/WhatIsMethIs/src/dto/medication/MedicationResDto.java
@@ -2,12 +2,14 @@ package com.WhatIsMethIs.src.dto.medication;
 
 import com.WhatIsMethIs.src.entity.Medication;
 import com.WhatIsMethIs.src.entity.MedicationConstant;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 @NoArgsConstructor
 public class MedicationResDto {
@@ -39,5 +41,28 @@ public class MedicationResDto {
             this.description = medication.getDescription();
 
         }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class MedicationIdRes{
+        private Long medicationId;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class MedicationShortInfoRes{
+        private String medicineName;
+        private String medicineImage;
+        private MedicationConstant.TakeMealTime takeMealTime; //아침, 점심, 저녁
+        private MedicationConstant.TakeBeforeAfter takeBeforeAfter; //식전, 식후
+        private int takeCapacity;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class MedicationShortInfoListRes{
+        private List<MedicationShortInfoRes> medicationShortInfos;
+        private int totalPages;
     }
 }

--- a/src/main/java/com/WhatIsMethIs/src/dto/medication/MedicationResDto.java
+++ b/src/main/java/com/WhatIsMethIs/src/dto/medication/MedicationResDto.java
@@ -52,6 +52,7 @@ public class MedicationResDto {
     @Getter
     @AllArgsConstructor
     public static class MedicationShortInfoRes{
+        private Long medicationId;
         private String medicineName;
         private String medicineImage;
         private MedicationConstant.TakeMealTime takeMealTime; //아침, 점심, 저녁

--- a/src/main/java/com/WhatIsMethIs/src/entity/Medication.java
+++ b/src/main/java/com/WhatIsMethIs/src/entity/Medication.java
@@ -1,5 +1,6 @@
 package com.WhatIsMethIs.src.entity;
 
+import com.WhatIsMethIs.src.dto.medication.MedicationReqDto.*;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.*;
 import lombok.*;
@@ -78,5 +79,19 @@ public class Medication {
         this.takeCycle = takeCycle;
         this.notificationTime = notificationTime;
         this.description = description;
+    }
+
+    public void updateMedication(MedicationInfoReq medicationInfo, Medicine newMedicine){
+        this.medicineId = newMedicine;
+        this.medicineName = medicationInfo.getMedicineName();
+        this.medicineImage = medicationInfo.getMedicineImage();
+        this.takeCapacity = medicationInfo.getTakeCapacity();
+        this.takeStartDate = medicationInfo.getTakeStartDate();
+        this.takeEndDate = medicationInfo.getTakeEndDate();
+        this.takeMealTime = medicationInfo.getTakeMealTime();
+        this.takeBeforeAfter = medicationInfo.getTakeBeforeAfter();
+        this.takeCycle = medicationInfo.getTakeCycle();
+        this.notificationTime = medicationInfo.getNotificationTime();
+        this.description = medicationInfo.getDescription();
     }
 }

--- a/src/main/java/com/WhatIsMethIs/src/repository/MedicationRepository.java
+++ b/src/main/java/com/WhatIsMethIs/src/repository/MedicationRepository.java
@@ -1,6 +1,9 @@
 package com.WhatIsMethIs.src.repository;
 
 import com.WhatIsMethIs.src.entity.Medication;
+import com.WhatIsMethIs.src.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +12,5 @@ import java.util.Optional;
 @Repository
 public interface MedicationRepository extends JpaRepository<Medication, Long> {
     Optional<Medication> findById(Long id);
+    Page<Medication> findByUserIdOrderByIdDesc(User userId, Pageable pageable);
 }

--- a/src/main/java/com/WhatIsMethIs/src/repository/MedicationRepository.java
+++ b/src/main/java/com/WhatIsMethIs/src/repository/MedicationRepository.java
@@ -7,10 +7,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface MedicationRepository extends JpaRepository<Medication, Long> {
     Optional<Medication> findById(Long id);
     Page<Medication> findByUserIdOrderByIdDesc(User userId, Pageable pageable);
+    List<Medication> findAllByUserId(User userId);
 }

--- a/src/main/java/com/WhatIsMethIs/src/service/MedicationService.java
+++ b/src/main/java/com/WhatIsMethIs/src/service/MedicationService.java
@@ -3,17 +3,27 @@ package com.WhatIsMethIs.src.service;
 import com.WhatIsMethIs.config.BaseException;
 import com.WhatIsMethIs.config.exception.medication.NotMyMedicationException;
 import com.WhatIsMethIs.config.exception.user.NotFoundUserIdException;
+import com.WhatIsMethIs.src.dto.medication.MedicationReqDto.*;
 import com.WhatIsMethIs.src.dto.medication.MedicationResDto.*;
 import com.WhatIsMethIs.src.entity.Medication;
 import com.WhatIsMethIs.config.exception.medication.NotFoundMedicationIdException;
+import com.WhatIsMethIs.src.entity.Medicine;
 import com.WhatIsMethIs.src.entity.User;
 import com.WhatIsMethIs.src.repository.MedicationRepository;
+import com.WhatIsMethIs.src.repository.MedicineRepository;
 import com.WhatIsMethIs.src.repository.UserRepository;
 import com.WhatIsMethIs.utils.TokenUtils;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -23,6 +33,9 @@ public class MedicationService {
 
     private final UserRepository userRepository;
     private final MedicationRepository medicationRepository;
+    private final MedicineRepository medicineRepository;
+
+    private static final String LOG_FORMAT = "Class : {}, Code : {}, Message : {}";
 
     //index로 복약정보 조회
     public MedicationInfoRes getMedicationWithIndex(Long index) throws BaseException {
@@ -39,6 +52,51 @@ public class MedicationService {
                 .medication(medication)
                 .build();
     }
+
+    //복약정보 등록
+    public MedicationIdRes createMedication(MedicationInfoReq medicationInfo) throws BaseException {
+        int userId= tokenUtils.getUserId();
+        User user = userRepository.findById(userId).orElseThrow(NotFoundUserIdException::new);
+
+        Medicine medicine = medicineRepository.findById(medicationInfo.getMedicineId()).orElseThrow();
+
+        Medication medication = Medication.builder()
+                .userId(user)
+                .medicineId(medicine)
+                .medicineName(medicationInfo.getMedicineName())
+                .medicineImage(medicationInfo.getMedicineImage())
+                .takeStartDate(medicationInfo.getTakeStartDate())
+                .takeEndDate(medicationInfo.getTakeEndDate())
+                .takeMealTime(medicationInfo.getTakeMealTime())
+                .takeBeforeAfter(medicationInfo.getTakeBeforeAfter())
+                .takeCapacity(medicationInfo.getTakeCapacity())
+                .takeCycle(medicationInfo.getTakeCycle())
+                .notificationTime(medicationInfo.getNotificationTime())
+                .description(medicationInfo.getDescription())
+                .build();
+
+        Medication medEntity = medicationRepository.save(medication);
+        return new MedicationIdRes(medEntity.getId());
+    }
+
+    //복약 정보 전체 조회 - 페이징 (10개 단위) -> 후에 수정될 수 있음
+    public MedicationShortInfoListRes getMedicationShortInfoList(int page) throws BaseException {
+        int userId= tokenUtils.getUserId();
+        User user = userRepository.findById(userId).orElseThrow(NotFoundUserIdException::new);
+
+        PageRequest pageRequest = PageRequest.of(page, 10);
+        Page<Medication> medications = medicationRepository.findByUserIdOrderByIdDesc(user, pageRequest);
+        log.warn(LOG_FORMAT, medications.stream().count());
+
+        List<MedicationShortInfoRes> medicationShortInfos = medications.stream()
+                .map(medication -> new MedicationShortInfoRes(medication.getMedicineName(),
+                        medication.getMedicineImage(), medication.getTakeMealTime(), medication.getTakeBeforeAfter(),
+                        medication.getTakeCapacity()))
+                .collect(Collectors.toList());
+
+        return new MedicationShortInfoListRes(medicationShortInfos, medications.getTotalPages());
+    }
+
 
 
 }

--- a/src/main/java/com/WhatIsMethIs/src/service/MedicationService.java
+++ b/src/main/java/com/WhatIsMethIs/src/service/MedicationService.java
@@ -63,7 +63,7 @@ public class MedicationService {
         int userId= tokenUtils.getUserId();
         User user = userRepository.findById(userId).orElseThrow(NotFoundUserIdException::new);
 
-        Medicine medicine = medicineRepository.findById(medicationInfo.getMedicineId()).orElseThrow();
+        Medicine medicine = medicineRepository.findById(medicationInfo.getMedicineId()).orElseThrow(NotFoundMedicineIdException::new);
 
         Medication medication = Medication.builder()
                 .userId(user)

--- a/src/main/java/com/WhatIsMethIs/src/service/MedicationService.java
+++ b/src/main/java/com/WhatIsMethIs/src/service/MedicationService.java
@@ -97,6 +97,41 @@ public class MedicationService {
         return new MedicationShortInfoListRes(medicationShortInfos, medications.getTotalPages());
     }
 
+    //index로 복약 정보 수정
+    public MedicationIdRes updateMedication(Long index, MedicationInfoReq medicationInfo) throws BaseException {
+        int userId= tokenUtils.getUserId();
+        User user = userRepository.findById(userId).orElseThrow(NotFoundUserIdException::new);
+
+        Medication medication = medicationRepository.findById(index).orElseThrow(NotFoundMedicationIdException::new);
+
+        if(!medication.getUserId().equals(user)){
+            throw new NotMyMedicationException();
+        }
+
+        Medicine newMedicine = medicineRepository.findById(medicationInfo.getMedicineId()).orElseThrow();
+        medication.updateMedication(medicationInfo, newMedicine);
+        return new MedicationIdRes(medication.getId());
+    }
+
+
+    //index 리스트로 복약 정보 삭제
+    public void deleteMedication(List<Long> medicationIdList) throws BaseException {
+        int userId= tokenUtils.getUserId();
+        User user = userRepository.findById(userId).orElseThrow(NotFoundUserIdException::new);
+
+        medicationIdList.forEach(id->{
+            Medication medication = medicationRepository.findById(id).orElseThrow(NotFoundMedicationIdException::new);
+
+            if(!medication.getUserId().equals(user)){
+                throw new NotMyMedicationException();
+            }
+
+            medicationRepository.delete(medication);
+        });
+
+
+    }
+
 
 
 }

--- a/src/main/java/com/WhatIsMethIs/src/service/MedicationService.java
+++ b/src/main/java/com/WhatIsMethIs/src/service/MedicationService.java
@@ -12,6 +12,7 @@ import com.WhatIsMethIs.src.entity.User;
 import com.WhatIsMethIs.src.repository.MedicationRepository;
 import com.WhatIsMethIs.src.repository.MedicineRepository;
 import com.WhatIsMethIs.src.repository.UserRepository;
+import com.WhatIsMethIs.utils.MedicationComparator;
 import com.WhatIsMethIs.utils.TokenUtils;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -80,7 +84,7 @@ public class MedicationService {
     }
 
     //복약 정보 전체 조회 - 페이징 (10개 단위) -> 후에 수정될 수 있음
-    public MedicationShortInfoListRes getMedicationShortInfoList(int page) throws BaseException {
+    public MedicationShortInfoListRes getAllMedication(int page) throws BaseException {
         int userId= tokenUtils.getUserId();
         User user = userRepository.findById(userId).orElseThrow(NotFoundUserIdException::new);
 
@@ -89,7 +93,7 @@ public class MedicationService {
         log.warn(LOG_FORMAT, medications.stream().count());
 
         List<MedicationShortInfoRes> medicationShortInfos = medications.stream()
-                .map(medication -> new MedicationShortInfoRes(medication.getMedicineName(),
+                .map(medication -> new MedicationShortInfoRes(medication.getId(), medication.getMedicineName(),
                         medication.getMedicineImage(), medication.getTakeMealTime(), medication.getTakeBeforeAfter(),
                         medication.getTakeCapacity()))
                 .collect(Collectors.toList());
@@ -128,8 +132,39 @@ public class MedicationService {
 
             medicationRepository.delete(medication);
         });
+    }
 
+    //오늘의 복약 정보 조회
+    public List<MedicationShortInfoRes> getTodayMedication() throws BaseException {
+        int userId= tokenUtils.getUserId();
+        User user = userRepository.findById(userId).orElseThrow(NotFoundUserIdException::new);
+        LocalDate today = LocalDate.now();
 
+        // 자신의 복약정보 다 가져와서 정렬
+        List<Medication> myMedications = medicationRepository.findAllByUserId(user);
+        Collections.sort(myMedications, new MedicationComparator());
+
+        List<MedicationShortInfoRes> medicationsToday = new ArrayList<>();
+        myMedications.forEach(medication -> {
+            LocalDate startDate = medication.getTakeStartDate();
+            LocalDate endDate = medication.getTakeEndDate();
+
+            if (startDate.isEqual(today)){
+                medicationsToday.add(new MedicationShortInfoRes(medication.getId(), medication.getMedicineName(), medication.getMedicineImage(), medication.getTakeMealTime(), medication.getTakeBeforeAfter(), medication.getTakeCapacity()));
+            } else if (startDate.isBefore(today) && endDate.isAfter(today)){
+                int cycle = medication.getTakeCycle();
+                LocalDate takeDate = startDate;
+
+                //startDate로부터 복약주기 더하기
+                while(takeDate.isBefore(today)){
+                    takeDate = takeDate.plusDays(cycle);
+                }
+                if(takeDate.isEqual(today)){
+                    medicationsToday.add(new MedicationShortInfoRes(medication.getId(), medication.getMedicineName(), medication.getMedicineImage(), medication.getTakeMealTime(), medication.getTakeBeforeAfter(), medication.getTakeCapacity()));
+                }
+            }
+        });
+        return medicationsToday;
     }
 
 

--- a/src/main/java/com/WhatIsMethIs/src/service/MedicationService.java
+++ b/src/main/java/com/WhatIsMethIs/src/service/MedicationService.java
@@ -2,6 +2,7 @@ package com.WhatIsMethIs.src.service;
 
 import com.WhatIsMethIs.config.BaseException;
 import com.WhatIsMethIs.config.exception.medication.NotMyMedicationException;
+import com.WhatIsMethIs.config.exception.medicine.NotFoundMedicineIdException;
 import com.WhatIsMethIs.config.exception.user.NotFoundUserIdException;
 import com.WhatIsMethIs.src.dto.medication.MedicationReqDto.*;
 import com.WhatIsMethIs.src.dto.medication.MedicationResDto.*;
@@ -112,7 +113,7 @@ public class MedicationService {
             throw new NotMyMedicationException();
         }
 
-        Medicine newMedicine = medicineRepository.findById(medicationInfo.getMedicineId()).orElseThrow();
+        Medicine newMedicine = medicineRepository.findById(medicationInfo.getMedicineId()).orElseThrow(NotFoundMedicineIdException::new);
         medication.updateMedication(medicationInfo, newMedicine);
         return new MedicationIdRes(medication.getId());
     }

--- a/src/main/java/com/WhatIsMethIs/utils/MedicationComparator.java
+++ b/src/main/java/com/WhatIsMethIs/utils/MedicationComparator.java
@@ -1,0 +1,20 @@
+package com.WhatIsMethIs.utils;
+
+import com.WhatIsMethIs.src.entity.Medication;
+
+import java.util.Comparator;
+
+public class MedicationComparator implements Comparator<Medication> {
+    @Override
+    public int compare(Medication med1, Medication med2) {
+        int mealTimeComparison = med1.getTakeMealTime().compareTo(med2.getTakeMealTime());
+
+        if (mealTimeComparison != 0) {
+            // TakeMealTime이 다르면, TakeMealTime 비교 우선
+            return mealTimeComparison;
+        } else {
+            // TakeMealTime이 같으면, TakeBeforeAfter 비교
+            return med1.getTakeBeforeAfter().compareTo(med2.getTakeBeforeAfter());
+        }
+    }
+}

--- a/src/main/java/com/WhatIsMethIs/utils/TakeMealTimeComparator.java
+++ b/src/main/java/com/WhatIsMethIs/utils/TakeMealTimeComparator.java
@@ -1,0 +1,22 @@
+package com.WhatIsMethIs.utils;
+
+import com.WhatIsMethIs.src.entity.MedicationConstant.*;
+
+import java.util.Comparator;
+
+public class TakeMealTimeComparator implements Comparator<TakeMealTime> {
+    @Override
+    public int compare(TakeMealTime mealTime1, TakeMealTime mealTime2) {
+        if (mealTime1 == mealTime2) {
+            return 0;
+        } else if (mealTime1 == TakeMealTime.BREAKFAST) {
+            return -1;
+        } else if (mealTime2 == TakeMealTime.BREAKFAST) {
+            return 1;
+        } else if (mealTime2 == TakeMealTime.DINNER) {
+            return -1;
+        } else {
+            return 1;
+        }
+    }
+}


### PR DESCRIPTION
## 🔥 Summary
- 오늘의 복약정보 조회
- 복약정보 전체 조회
- 복약정보 등록
- index로 복약정보 수정
- index 리스트로 복약정보 삭제

## ✏️ Describe your changes
### 복약정보 API 공통 부분
모든 복약정보 관련 API에 아래 로직을 넣어서 로그인 한 유저 정보를 확인하게 했습니다. 
https://github.com/WhatIsMethIs/WhatIsMethIs-Server/blob/13ec45bad305042296214d61a219ecb32715d8e2/src/main/java/com/WhatIsMethIs/src/service/MedicationService.java#L63-L64

### 복약정보 전체 조회
복약정보 전체 조회 시 페이징 처리를 해서 한 번에 10개씩 조회되도록 했습니다. 페이지는 0번부터 시작합니다!!!
https://github.com/WhatIsMethIs/WhatIsMethIs-Server/blob/13ec45bad305042296214d61a219ecb32715d8e2/src/main/java/com/WhatIsMethIs/src/service/MedicationService.java#L88-L103

response는 아래 그림과 같고, swagger에서도 확인하실 수 있습니당
![image](https://github.com/WhatIsMethIs/WhatIsMethIs-Server/assets/95969941/2725f070-8193-4592-8fcf-558b8947b01e)

### 복약정보 수정
복약정보 수정도 index로 복약정보 조회와 마찬가지로 자신의 복약정보여야 수정이 가능합니다
https://github.com/WhatIsMethIs/WhatIsMethIs-Server/blob/13ec45bad305042296214d61a219ecb32715d8e2/src/main/java/com/WhatIsMethIs/src/service/MedicationService.java#L112-L114

### 복약정보 삭제
복약정보 삭제는 디자인한 화면 상 여러 개의 복약정보를 한 번에 삭제하는 것이 자연스러워서 복약정보 index 리스트를 받아 한 번에 삭제하는 것으로 구현했습니다.. 받은 복약정보 리스트 중 하나라도 자신의 복약정보가 아니거나, 이미 삭제된 복약정보라면 예외를 반환하고, 삭제처리되지 않습니다!
https://github.com/WhatIsMethIs/WhatIsMethIs-Server/blob/13ec45bad305042296214d61a219ecb32715d8e2/src/main/java/com/WhatIsMethIs/src/service/MedicationService.java#L127-L135

### 오늘의 복약정보 조회
오늘의 복약정보 구현 시 자신의 복약 정보를 모두 가져와 복약시작일<= 오늘 날짜 <=복약종료일 이면서 오늘이 복약주기에 포함되는 날인지를 확인 후 해당되는 복약정보 리스트만 리턴합니다.  리스트는 복약시간이 아침>점심>저녁, 식전>식후 순으로 정렬되어 리턴됩니다.

먼저 여기에서  아침>점심>저녁, 식전>식후 순으로 리스트를 정렬합니다.
https://github.com/WhatIsMethIs/WhatIsMethIs-Server/blob/13ec45bad305042296214d61a219ecb32715d8e2/src/main/java/com/WhatIsMethIs/src/service/MedicationService.java#L144-L146

아침>점심>저녁 순서로 정렬하기 위해 Custom TakeMealTime Comparator를 직접 만들었고
https://github.com/WhatIsMethIs/WhatIsMethIs-Server/blob/13ec45bad305042296214d61a219ecb32715d8e2/src/main/java/com/WhatIsMethIs/utils/TakeMealTimeComparator.java#L7-L22

`아침 == 아침` 의 경우와 같이 비교하는 복약 정보의 TakeMealTime이 동일한 경우 식전, 식후를 비교하게 했습니다.
https://github.com/WhatIsMethIs/WhatIsMethIs-Server/blob/13ec45bad305042296214d61a219ecb32715d8e2/src/main/java/com/WhatIsMethIs/utils/MedicationComparator.java#L7-L20

이후 복약시작일<= 오늘 날짜 <=복약종료일 이면서 오늘이 복약주기에 포함되는 날인지를 확인 후 해당되는 복약정보를 리턴될 리스트에 추가하는 로직입니다.
https://github.com/WhatIsMethIs/WhatIsMethIs-Server/blob/13ec45bad305042296214d61a219ecb32715d8e2/src/main/java/com/WhatIsMethIs/src/service/MedicationService.java#L148-L169

## 📖 Review Point
현재는 복약시작일이 오늘 날짜와 같을 때 오늘의 복약정보에서 볼 수 있는데 복약종료일이 오늘 날짜와 같지만 복약주기에 포함되지 않는 경우는 오늘의 복약정보에서 볼 수 없어도 될까요..? (저는 볼 수 없어야 한다고 생각함니다..😅)
Ex) 복약 시작일: 2023-08-17, 복약 종료일: 2023-08-24, 복약 주기: 2일, 오늘 날짜: 2023-08-24
